### PR TITLE
[JB][OPS-12219] audit event fixes:

### DIFF
--- a/app/models/audit/BankClaimAttempt.scala
+++ b/app/models/audit/BankClaimAttempt.scala
@@ -19,13 +19,13 @@ package models.audit
 import models.dateofbirth.DateOfBirth
 import models.ecospend.BankFriendlyName
 import models.journeymodels.JourneyType
-import models.{AmountInPence, P800Reference, Nino}
-import play.api.libs.json.{Json, OWrites, Writes, JsString}
+import models.{Nino, P800Reference}
+import play.api.libs.json.{JsString, Json, OWrites, Writes}
 
 final case class BankClaimAttempt(
     outcome:              BankClaimOutcome,
     userEnteredDetails:   BankClaimUserEnteredDetails,
-    repaymentAmount:      Option[AmountInPence],
+    repaymentAmount:      Option[BigDecimal],
     repaymentInformation: Option[RepaymentInformation],
     name:                 Option[Name],
     address:              Option[Address]
@@ -77,10 +77,12 @@ final case class BankClaimUserEnteredDetails(
 )
 
 object BankClaimUserEnteredDetails {
-  implicit val journeyTypeWrites: Writes[JourneyType] = Writes(journeyType => journeyType match {
+  implicit val journeyTypeWrites: Writes[JourneyType] = Writes {
     case JourneyType.BankTransfer => JsString("bank")
     case JourneyType.Cheque       => JsString("cheque")
-  })
+  }
+
+  implicit val dateOfBirthWrites: Writes[DateOfBirth] = Writes(dateOfBirth => JsString(dateOfBirth.`formatYYYY-MM-DD`))
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
   implicit val writes: OWrites[BankClaimUserEnteredDetails] = Json.writes[BankClaimUserEnteredDetails]

--- a/app/models/audit/UserLoginSelection.scala
+++ b/app/models/audit/UserLoginSelection.scala
@@ -22,7 +22,7 @@ final case class UserLoginSelection(
     login:              Login,
     ipAddressLockedout: IpAddressLockedout
 ) extends AuditDetail {
-  val auditType: String = "userLoginSelection"
+  val auditType: String = "UserLoginSelection"
 }
 
 object UserLoginSelection {

--- a/app/models/audit/ValidateUserDetails.scala
+++ b/app/models/audit/ValidateUserDetails.scala
@@ -20,13 +20,13 @@ import edh.Postcode
 import models.attemptmodels.NumberOfAttempts
 import models.dateofbirth.DateOfBirth
 import models.journeymodels.JourneyType
-import models.{AmountInPence, P800Reference, Nino}
+import models.{P800Reference, Nino}
 import play.api.libs.json.{Json, OWrites, Writes, JsString}
 
 final case class ValidateUserDetails(
     outcome:              Outcome,
     userEnteredDetails:   UserEnteredDetails,
-    repaymentAmount:      Option[AmountInPence],
+    repaymentAmount:      Option[BigDecimal],
     repaymentInformation: Option[RepaymentInformation],
     name:                 Option[Name],
     address:              Option[Address]
@@ -79,10 +79,10 @@ final case class UserEnteredDetails(
 )
 
 object UserEnteredDetails {
-  implicit val journeyTypeWrites: Writes[JourneyType] = Writes(journeyType => journeyType match {
+  implicit val journeyTypeWrites: Writes[JourneyType] = Writes {
     case JourneyType.BankTransfer => JsString("bank")
     case JourneyType.Cheque       => JsString("cheque")
-  })
+  }
 
   implicit val dateOfBirthWrites: Writes[DateOfBirth] = Writes(dateOfBirth => JsString(dateOfBirth.`formatYYYY-MM-DD`))
 

--- a/app/services/AuditService.scala
+++ b/app/services/AuditService.scala
@@ -74,8 +74,8 @@ class AuditService @Inject() (
     ValidateUserDetails(
       outcome              = toOutcome(attemptInfo, isSuccessful, apiResponsibleForFailure, failureReasons.getOrElse(Seq.empty)),
       userEnteredDetails   = toUserEnteredDetails(journey),
-      repaymentAmount      = journey.referenceCheckResult.fold[Option[AmountInPence]](None) {
-        case p800ReferenceChecked: ValidateReferenceResult.P800ReferenceChecked => Some(AmountInPence(p800ReferenceChecked.paymentAmount))
+      repaymentAmount      = journey.referenceCheckResult.fold[Option[BigDecimal]](None) {
+        case p800ReferenceChecked: ValidateReferenceResult.P800ReferenceChecked => Some(AmountInPence(p800ReferenceChecked.paymentAmount).inPounds)
         case _ => None
       },
       repaymentInformation = journey.referenceCheckResult.fold[Option[RepaymentInformation]](None) {
@@ -121,8 +121,8 @@ class AuditService @Inject() (
     BankClaimAttempt(
       outcome              = toBankClaimOutcome(actionsOutcome, failureReasons),
       userEnteredDetails   = toBankClaimUserEnteredDetails(journey),
-      repaymentAmount      = journey.referenceCheckResult.fold[Option[AmountInPence]](None) {
-        case p800ReferenceChecked: ValidateReferenceResult.P800ReferenceChecked => Some(AmountInPence(p800ReferenceChecked.paymentAmount))
+      repaymentAmount      = journey.referenceCheckResult.fold[Option[BigDecimal]](None) {
+        case p800ReferenceChecked: ValidateReferenceResult.P800ReferenceChecked => Some(AmountInPence(p800ReferenceChecked.paymentAmount).inPounds)
         case _ => None
       },
       repaymentInformation = journey.referenceCheckResult.fold[Option[RepaymentInformation]](None) {

--- a/test/pagespecs/CheckYourAnswersPageSpec.scala
+++ b/test/pagespecs/CheckYourAnswersPageSpec.scala
@@ -171,7 +171,7 @@ class CheckYourAnswersPageSpec extends ItSpec {
       getJourneyFromDatabase(tdAll.journeyId) shouldBeLike j
 
       AuditConnectorStub.verifyEventAudited(
-        "ValidateUserDetails",
+        AuditConnectorStub.validateUserDetailsAuditType,
         Json.parse(
           //format=JSON
           """
@@ -187,7 +187,7 @@ class CheckYourAnswersPageSpec extends ItSpec {
               "nino": "LM001014C",
               "dob": "2000-01-01"
             },
-            "repaymentAmount": 1234,
+            "repaymentAmount": 12.34,
             "repaymentInformation": {
               "reconciliationIdentifier": 123,
               "paymentNumber": 12345678,
@@ -213,7 +213,7 @@ class CheckYourAnswersPageSpec extends ItSpec {
       getJourneyFromDatabase(tdAll.journeyId) shouldBeLike j
 
       AuditConnectorStub.verifyEventAudited(
-        "ValidateUserDetails",
+        AuditConnectorStub.validateUserDetailsAuditType,
         Json.parse(
           //format=JSON
           """
@@ -228,7 +228,7 @@ class CheckYourAnswersPageSpec extends ItSpec {
               "p800Reference": 12345678,
               "nino": "LM001014C"
             },
-            "repaymentAmount": 1234,
+            "repaymentAmount": 12.34,
             "repaymentInformation": {
               "reconciliationIdentifier": 123,
               "paymentNumber": 12345678,
@@ -290,7 +290,7 @@ class CheckYourAnswersPageSpec extends ItSpec {
       getFailedAttemptCount() shouldBe Some(1)
 
       AuditConnectorStub.verifyEventAudited(
-        "ValidateUserDetails",
+        AuditConnectorStub.validateUserDetailsAuditType,
         Json.parse(
           //format=JSON
           """
@@ -331,7 +331,7 @@ class CheckYourAnswersPageSpec extends ItSpec {
       getFailedAttemptCount() shouldBe Some(1)
 
       AuditConnectorStub.verifyEventAudited(
-        "ValidateUserDetails",
+        AuditConnectorStub.validateUserDetailsAuditType,
         Json.parse(
           //format=JSON
           """
@@ -404,7 +404,7 @@ class CheckYourAnswersPageSpec extends ItSpec {
       getFailedAttemptCount() shouldBe Some(3)
 
       AuditConnectorStub.verifyEventAudited(
-        "ValidateUserDetails",
+        AuditConnectorStub.validateUserDetailsAuditType,
         Json.parse(
           //format=JSON
           """
@@ -445,7 +445,7 @@ class CheckYourAnswersPageSpec extends ItSpec {
       getFailedAttemptCount() shouldBe Some(3)
 
       AuditConnectorStub.verifyEventAudited(
-        "ValidateUserDetails",
+        AuditConnectorStub.validateUserDetailsAuditType,
         Json.parse(
           //format=JSON
           """
@@ -494,7 +494,7 @@ class CheckYourAnswersPageSpec extends ItSpec {
       TraceIndividualStub.verifyNoneTraceIndividual()
 
       AuditConnectorStub.verifyEventAudited(
-        "ValidateUserDetails",
+        AuditConnectorStub.validateUserDetailsAuditType,
         Json.parse(
           //format=JSON
           """
@@ -530,7 +530,7 @@ class CheckYourAnswersPageSpec extends ItSpec {
       TraceIndividualStub.verifyNoneTraceIndividual()
 
       AuditConnectorStub.verifyEventAudited(
-        "ValidateUserDetails",
+        AuditConnectorStub.validateUserDetailsAuditType,
         Json.parse(
           //format=JSON
           """

--- a/test/pagespecs/DoYouWantToSignInPageSpec.scala
+++ b/test/pagespecs/DoYouWantToSignInPageSpec.scala
@@ -37,7 +37,7 @@ class DoYouWantToSignInPageSpec extends ItSpec {
     getJourneyFromDatabase(tdAll.journeyId) shouldBeLike tdAll.journeyStarted
 
     AuditConnectorStub.verifyEventAudited(
-      "userLoginSelection",
+      AuditConnectorStub.userLoginSelectionAuditType,
       Json.parse(
         //format=JSON
         """
@@ -59,7 +59,7 @@ class DoYouWantToSignInPageSpec extends ItSpec {
     getJourneyFromDatabase(tdAll.journeyId) shouldBeLike tdAll.journeyStarted
 
     AuditConnectorStub.verifyEventAudited(
-      "userLoginSelection",
+      AuditConnectorStub.userLoginSelectionAuditType,
       Json.parse(
         //format=JSON
         """
@@ -81,7 +81,7 @@ class DoYouWantToSignInPageSpec extends ItSpec {
     pages.youCannotConfirmYourIdentityYetSpec.assertPageIsDisplayed()
 
     AuditConnectorStub.verifyEventAudited(
-      "userLoginSelection",
+      AuditConnectorStub.userLoginSelectionAuditType,
       Json.parse(
         //format=JSON
         """
@@ -101,7 +101,7 @@ class DoYouWantToSignInPageSpec extends ItSpec {
     pages.doYouWantToSignInPage.assertPageShowsWithErrors()
     getJourneyFromDatabase(tdAll.journeyId) shouldBeLike tdAll.journeyStarted
 
-    AuditConnectorStub.verifyNoAuditEvent("userLoginSelection")
+    AuditConnectorStub.verifyNoAuditEvent(AuditConnectorStub.userLoginSelectionAuditType)
   }
 
   "Render page in Welsh" in {
@@ -119,7 +119,7 @@ class DoYouWantToSignInPageSpec extends ItSpec {
     pages.doYouWantToSignInPage.assertPageShowsWithErrorsInWelsh()
     getJourneyFromDatabase(tdAll.journeyId) shouldBeLike tdAll.journeyStarted
 
-    AuditConnectorStub.verifyNoAuditEvent("userLoginSelection")
+    AuditConnectorStub.verifyNoAuditEvent(AuditConnectorStub.userLoginSelectionAuditType)
   }
 
 }

--- a/test/pagespecs/VerifyingYourBankAccountPageSpec.scala
+++ b/test/pagespecs/VerifyingYourBankAccountPageSpec.scala
@@ -51,7 +51,7 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
     EdhStub.verifyGetBankDetailsRiskResult(tdAll.claimId, tdAll.correlationId)
     P800RefundsExternalApiStub.verifyIsValid(tdAll.consentId)
     MakeBacsRepaymentStub.verifyNone(tdAll.nino)
-    AuditConnectorStub.verifyNoAuditEvent("BankClaimAttemptMade")
+    AuditConnectorStub.verifyNoAuditEvent(AuditConnectorStub.bankClaimAttemptMadeAuditType)
   }
 
   "/verify-bank-account renders the 'Refund Request not Submitted' page when the Consent Status is Canceled" in {
@@ -70,7 +70,7 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
     EdhStub.verifyGetBankDetailsRiskResult(tdAll.claimId, tdAll.correlationId)
     P800RefundsExternalApiStub.verifyIsValid(tdAll.consentId)
     MakeBacsRepaymentStub.verifyNone(tdAll.nino)
-    AuditConnectorStub.verifyNoAuditEvent("BankClaimAttemptMade")
+    AuditConnectorStub.verifyNoAuditEvent(AuditConnectorStub.bankClaimAttemptMadeAuditType)
   }
 
   "/verify-bank-account renders the 'Refund Request not Submitted' page when the Name Matching Fails" in {
@@ -89,7 +89,7 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
     P800RefundsExternalApiStub.verifyIsValid(tdAll.consentId)
     MakeBacsRepaymentStub.verifyNone(tdAll.nino)
     AuditConnectorStub.verifyEventAudited(
-      "BankClaimAttemptMade",
+      AuditConnectorStub.bankClaimAttemptMadeAuditType,
       Json.parse(
         //format=JSON
         """
@@ -108,13 +108,9 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
             "chosenBank": "Barclays Personal",
             "p800Reference": 12345678,
             "nino": "LM001014C",
-            "dob": {
-              "dayOfMonth": "1",
-              "month": "1",
-              "year": "2000"
-            }
+            "dob": "2000-01-01"
           },
-          "repaymentAmount": 1234,
+          "repaymentAmount": 12.34,
           "repaymentInformation": {
             "reconciliationIdentifier": 123,
             "paymentNumber": 12345678,
@@ -175,7 +171,7 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
     P800RefundsExternalApiStub.verifyIsValid(tdAll.consentId)
     MakeBacsRepaymentStub.verifyNone(tdAll.nino)
     AuditConnectorStub.verifyEventAudited(
-      "BankClaimAttemptMade",
+      AuditConnectorStub.bankClaimAttemptMadeAuditType,
       Json.parse(
         """
         {
@@ -193,13 +189,9 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
             "chosenBank": "Barclays Personal",
             "p800Reference": 12345678,
             "nino": "LM001014C",
-            "dob": {
-              "dayOfMonth": "1",
-              "month": "1",
-              "year": "2000"
-            }
+            "dob": "2000-01-01"
           },
-          "repaymentAmount": 1234,
+          "repaymentAmount": 12.34,
           "repaymentInformation": {
             "reconciliationIdentifier": 123,
             "paymentNumber": 12345678,
@@ -259,7 +251,7 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
     P800RefundsExternalApiStub.verifyIsValid(tdAll.consentId)
     MakeBacsRepaymentStub.verifyNone(tdAll.nino)
     AuditConnectorStub.verifyEventAudited(
-      "BankClaimAttemptMade",
+      AuditConnectorStub.bankClaimAttemptMadeAuditType,
       Json.parse(
         """
         {
@@ -277,13 +269,9 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
             "chosenBank": "Barclays Personal",
             "p800Reference": 12345678,
             "nino": "LM001014C",
-            "dob": {
-              "dayOfMonth": "1",
-              "month": "1",
-              "year": "2000"
-            }
+            "dob": "2000-01-01"
           },
-          "repaymentAmount": 1234,
+          "repaymentAmount": 12.34,
           "repaymentInformation": {
             "reconciliationIdentifier": 123,
             "paymentNumber": 12345678,
@@ -325,7 +313,7 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
     EdhStub.verifyGetBankDetailsRiskResult(tdAll.claimId, tdAll.correlationId)
     P800RefundsExternalApiStub.verifyIsValid(tdAll.consentId)
     MakeBacsRepaymentStub.verifyNone(tdAll.nino)
-    AuditConnectorStub.verifyNoAuditEvent("BankClaimAttemptMade")
+    AuditConnectorStub.verifyNoAuditEvent(AuditConnectorStub.bankClaimAttemptMadeAuditType)
   }
 
   "/verify-bank-account renders the 'We are verifying your bank account' page when using the fallback joint account name" in {
@@ -362,7 +350,7 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
     EdhStub.verifyGetBankDetailsRiskResult(tdAll.claimId, tdAll.correlationId)
     P800RefundsExternalApiStub.verifyIsValid(tdAll.consentId)
     MakeBacsRepaymentStub.verifyNone(tdAll.nino)
-    AuditConnectorStub.verifyNoAuditEvent("BankClaimAttemptMade")
+    AuditConnectorStub.verifyNoAuditEvent(AuditConnectorStub.bankClaimAttemptMadeAuditType)
   }
 
   "clicking 'refresh this page' refreshes the page - showing the same page if bank is not verified yet" in {
@@ -383,7 +371,7 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
     EdhStub.verifyGetBankDetailsRiskResult(tdAll.claimId, tdAll.correlationId)
     P800RefundsExternalApiStub.verifyIsValid(tdAll.consentId, 2)
     MakeBacsRepaymentStub.verifyNone(tdAll.nino)
-    AuditConnectorStub.verifyNoAuditEvent("BankClaimAttemptMade")
+    AuditConnectorStub.verifyNoAuditEvent(AuditConnectorStub.bankClaimAttemptMadeAuditType)
   }
 
   "redirect to bank transfer 'Request received' page when verification call returns Successful" in {
@@ -414,7 +402,7 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
     MakeBacsRepaymentStub.verify(tdAll.nino, tdAll.correlationId)
 
     AuditConnectorStub.verifyEventAudited(
-      "BankClaimAttemptMade",
+      AuditConnectorStub.bankClaimAttemptMadeAuditType,
       Json.parse(
         //format=JSON
         """
@@ -432,13 +420,9 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
             "chosenBank": "Barclays Personal",
             "p800Reference": 12345678,
             "nino": "LM001014C",
-            "dob": {
-              "dayOfMonth": "1",
-              "month": "1",
-              "year": "2000"
-            }
+            "dob": "2000-01-01"
           },
-          "repaymentAmount": 1234,
+          "repaymentAmount": 12.34,
           "repaymentInformation": {
             "reconciliationIdentifier": 123,
             "paymentNumber": 12345678,
@@ -491,7 +475,7 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
     pages.refundRequestNotSubmittedPage.assertPageIsDisplayed()
     P800RefundsExternalApiStub.verifyIsValid(tdAll.consentId, 2)
     AuditConnectorStub.verifyEventAudited(
-      "BankClaimAttemptMade",
+      AuditConnectorStub.bankClaimAttemptMadeAuditType,
       Json.parse(
         //format=JSON
         """
@@ -511,13 +495,9 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
             "chosenBank": "Barclays Personal",
             "p800Reference": 12345678,
             "nino": "LM001014C",
-            "dob": {
-              "dayOfMonth": "1",
-              "month": "1",
-              "year": "2000"
-            }
+            "dob": "2000-01-01"
           },
-          "repaymentAmount": 1234,
+          "repaymentAmount": 12.34,
           "repaymentInformation": {
             "reconciliationIdentifier": 123,
             "paymentNumber": 12345678,
@@ -559,7 +539,7 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
     pages.verifyingBankAccountPage.assertPageIsDisplayed()
     EcospendStub.AccountStub.accountSummaryValidate(numberOfRequests = 1, tdAll.consentId)
     EdhStub.verifyGetBankDetailsRiskResult(tdAll.claimId, tdAll.correlationId, numberOfRequests = 1)
-    AuditConnectorStub.verifyNoAuditEvent("BankClaimAttemptMade")
+    AuditConnectorStub.verifyNoAuditEvent(AuditConnectorStub.bankClaimAttemptMadeAuditType)
   }
 
   "redirect to 'Request received' page when EDH call results in nextAction=DoNotPay" in {
@@ -585,7 +565,7 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
     P800RefundsExternalApiStub.verifyIsValid(tdAll.consentId)
     MakeBacsRepaymentStub.verifyNone(tdAll.nino)
     AuditConnectorStub.verifyEventAudited(
-      "BankClaimAttemptMade",
+      AuditConnectorStub.bankClaimAttemptMadeAuditType,
       Json.parse(
         //format=JSON
         """
@@ -605,13 +585,9 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
             "chosenBank": "Barclays Personal",
             "p800Reference": 12345678,
             "nino": "LM001014C",
-            "dob": {
-              "dayOfMonth": "1",
-              "month": "1",
-              "year": "2000"
-            }
+            "dob": "2000-01-01"
           },
-          "repaymentAmount": 1234,
+          "repaymentAmount": 12.34,
           "repaymentInformation": {
             "reconciliationIdentifier": 123,
             "paymentNumber": 12345678,
@@ -653,7 +629,7 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
     MakeBacsRepaymentStub.verify(tdAll.nino, tdAll.correlationId)
 
     AuditConnectorStub.verifyEventAudited(
-      "BankClaimAttemptMade",
+      AuditConnectorStub.bankClaimAttemptMadeAuditType,
       Json.parse(
         //format=JSON
         """
@@ -675,13 +651,9 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
             "chosenBank": "Barclays Personal",
             "p800Reference": 12345678,
             "nino": "LM001014C",
-            "dob": {
-              "dayOfMonth": "1",
-              "month": "1",
-              "year": "2000"
-            }
+            "dob": "2000-01-01"
           },
-          "repaymentAmount": 1234,
+          "repaymentAmount": 12.34,
           "repaymentInformation": {
             "reconciliationIdentifier": 123,
             "paymentNumber": 12345678,
@@ -721,7 +693,7 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
     EdhStub.verifyGetBankDetailsRiskResult(tdAll.claimId, tdAll.correlationId)
     MakeBacsRepaymentStub.verify(tdAll.nino, tdAll.correlationId)
     AuditConnectorStub.verifyEventAudited(
-      "BankClaimAttemptMade",
+      AuditConnectorStub.bankClaimAttemptMadeAuditType,
       Json.parse(
         //format=JSON
         """
@@ -743,13 +715,9 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
             "chosenBank": "Barclays Personal",
             "p800Reference": 12345678,
             "nino": "LM001014C",
-            "dob": {
-              "dayOfMonth": "1",
-              "month": "1",
-              "year": "2000"
-            }
+            "dob": "2000-01-01"
           },
-          "repaymentAmount": 1234,
+          "repaymentAmount": 12.34,
           "repaymentInformation": {
             "reconciliationIdentifier": 123,
             "paymentNumber": 12345678,
@@ -790,7 +758,7 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
     EdhStub.verifyGetBankDetailsRiskResult(tdAll.claimId, tdAll.correlationId)
     MakeBacsRepaymentStub.verify(tdAll.nino, tdAll.correlationId)
     AuditConnectorStub.verifyEventAudited(
-      "BankClaimAttemptMade",
+      AuditConnectorStub.bankClaimAttemptMadeAuditType,
       Json.parse(
         //format=JSON
         """
@@ -812,13 +780,9 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
             "chosenBank": "Barclays Personal",
             "p800Reference": 12345678,
             "nino": "LM001014C",
-            "dob": {
-              "dayOfMonth": "1",
-              "month": "1",
-              "year": "2000"
-            }
+            "dob": "2000-01-01"
           },
-          "repaymentAmount": 1234,
+          "repaymentAmount": 12.34,
           "repaymentInformation": {
             "reconciliationIdentifier": 123,
             "paymentNumber": 12345678,
@@ -856,7 +820,7 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
     EdhStub.verifyGetBankDetailsRiskResult(tdAll.claimId, tdAll.correlationId)
     MakeBacsRepaymentStub.verifyNone(tdAll.nino)
     AuditConnectorStub.verifyEventAudited(
-      "BankClaimAttemptMade",
+      AuditConnectorStub.bankClaimAttemptMadeAuditType,
       Json.parse(
         //format=JSON
         """
@@ -876,13 +840,9 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
             "chosenBank": "Barclays Personal",
             "p800Reference": 12345678,
             "nino": "LM001014C",
-            "dob": {
-              "dayOfMonth": "1",
-              "month": "1",
-              "year": "2000"
-            }
+            "dob": "2000-01-01"
           },
-          "repaymentAmount": 1234,
+          "repaymentAmount": 12.34,
           "repaymentInformation": {
             "reconciliationIdentifier": 123,
             "paymentNumber": 12345678,
@@ -925,7 +885,7 @@ class VerifyingYourBankAccountPageSpec extends ItSpec {
     CaseManagementStub.verifyNotifyCaseManagement(tdAll.clientUId, tdAll.correlationId)
     P800RefundsExternalApiStub.verifyIsValid(tdAll.consentId)
     MakeBacsRepaymentStub.verifyNone(tdAll.nino)
-    AuditConnectorStub.verifyNoAuditEvent("BankClaimAttemptMade")
+    AuditConnectorStub.verifyNoAuditEvent(AuditConnectorStub.bankClaimAttemptMadeAuditType)
   }
 
 }

--- a/test/testsupport/stubs/AuditConnectorStub.scala
+++ b/test/testsupport/stubs/AuditConnectorStub.scala
@@ -47,6 +47,9 @@ object AuditConnectorStub {
         )
     )
 
+  val userLoginSelectionAuditType: String = "UserLoginSelection"
+  val bankClaimAttemptMadeAuditType: String = "BankClaimAttemptMade"
+  val validateUserDetailsAuditType: String = "ValidateUserDetails"
   val chequeClaimAttemptMadeAuditType: String = "ChequeClaimAttemptMade"
 
   /*


### PR DESCRIPTION
- format dob in BankClaimAttemptMade as yyyy-mm-dd
- userLoginSelection -> UserLoginSelection
- repaymentAmount is now Bigecimal
- refactor auditType strings in tests to one place so we don't type the string each time